### PR TITLE
float-nan-p for IEEE-754 compliant implementations

### DIFF
--- a/float-features.lisp
+++ b/float-features.lisp
@@ -133,7 +133,7 @@
   #+ecl (ext:float-nan-p float)
   #+sbcl (sb-ext:float-nan-p float)
   #-(or abcl allegro ccl clasp cmucl ecl sbcl)
-  NIL)
+  (/= float float))
 
 (defun keep (list &rest keeps)
   (loop for item in list


### PR DESCRIPTION
see https://en.wikipedia.org/wiki/NaN, there are multiple ways to detect NaNs, numerical equality with itself being one of them. NaN is not numerically equal to NaN.