### PR TITLE
Corrected typo regarding ECL package

### DIFF
--- a/float-features.lisp
+++ b/float-features.lisp
@@ -124,7 +124,7 @@
   #+ccl (ccl::infinity-p float)
   #+clasp (ext:float-infinity-p float)
   #+cmucl (extensions:float-infinity-p float)
-  #+ecl (extensions:float-infinity-p float)
+  #+ecl (ext:float-infinity-p float)
   #+sbcl (sb-ext:float-infinity-p float)
   #-(or abcl allegro ccl clasp cmucl ecl sbcl)
   (etypecase float


### PR DESCRIPTION
* float-features.lisp (float-infinity-p):
The package where float-infinity-p lives for the ECL compiler is not "extensions:" but "ext:"