### PR TITLE
Fix float-nan-p on Allegro

### DIFF
--- a/float-features.lisp
+++ b/float-features.lisp
@@ -169,7 +169,7 @@
 
 (defun float-nan-p (float)
   #+abcl (system:float-nan-p float)
-  #+allegro (excl:nanp float)
+  #+allegro (and (excl:nanp float) t)
   #+ccl (and (ccl::nan-or-infinity-p float)
              (not (ccl::infinity-p float)))
   #+clasp (ext:float-nan-p float)


### PR DESCRIPTION
excl:nanp on Allegro returns nil or NaN. This modifies float-nan-p on Allegro to return t instead of NaN.