### PR TITLE
Fix WITH-FLOAT-TRAPS-MASKED for :INVALID trap on ECL

### DIFF
--- a/float-features.lisp
+++ b/float-features.lisp
@@ -231,7 +231,7 @@
                                         (:underflow 'floating-point-underflow)
                                         (:overflow 'floating-point-overflow)
                                         (:inexact 'floating-point-inexact)
-                                        (:invalid 'floating-point-invalid)
+                                        (:invalid 'floating-point-invalid-operation)
                                         (:divide-by-zero 'division-by-zero))
                         when keyword collect `(ext:trap-fpe ',keyword NIL))
                 NIL ,@body)


### PR DESCRIPTION
The symbol name for the :invalid trap is wrong ECL, see
https://ecl.common-lisp.dev/static/manual/Numbers.html#Numbers-_002d-Floating-point-exceptions