### PR TITLE
Fix warnings in tests.

### DIFF
--- a/test-float-features.lisp
+++ b/test-float-features.lisp
@@ -11,93 +11,69 @@
     :compile-at :compile-time
     (parachute:true
      (float-features:float-infinity-p
-      (flet ((foo () (read-from-string "0.0"))
-             (bar () (read-from-string "23")))
-        (float-features:with-float-traps-masked (:divide-by-zero)
-          (/ (bar) (foo)))))))
+      (float-features:with-float-traps-masked (:divide-by-zero)
+        (/ (read-from-string "23") (read-from-string "0.0"))))))
 
 (parachute:define-test float-features-divide-by-fp-zero-non-trapped
     :compile-at :compile-time
     (parachute:true
      (handler-case
-         (flet ((foo () (read-from-string "0.0"))
-                (bar () (read-from-string "23")))
-           (float-features:with-float-traps-masked ()
-             (/ (bar) (foo))))
+         (float-features:with-float-traps-masked ()
+           (/ (read-from-string "23") (read-from-string "0.0")))
        (division-by-zero (error)
          (values t error)))))
-
-(defun foo-float-features-1 (n)
-  most-positive-long-float)
-
-(defun bar-float-features-1 (n)
-  most-positive-long-float)
 
 (parachute:define-test float-features-overflow-trapped
     :compile-at :compile-time
     (parachute:true
      (float-features:float-infinity-p
       (float-features:with-float-traps-masked (:overflow :inexact)
-        (let ((n (random 100)))
-          (+ (foo-float-features-1 n) (bar-float-features-1 n)))))))
+        (+ (symbol-value 'most-positive-long-float)
+           (symbol-value 'most-positive-long-float))))))
 
 (parachute:define-test float-features-overflow-non-trapped
     :compile-at :compile-time
     (parachute:true
      (handler-case
-         (let ((n (random 100)))
-           (float-features:with-float-traps-masked ()
-             (+ (foo-float-features-1 n) (bar-float-features-1 n))))
+         (float-features:with-float-traps-masked ()
+           (+ (symbol-value 'most-positive-long-float)
+              (symbol-value 'most-positive-long-float)))
        (floating-point-overflow (error)
          (values t error)))))
-
-(defun foo-float-features-2 (n)
-  (- most-positive-long-float (read-from-string "3")))
-
-(defun bar-float-features-2 (n)
-  (- most-positive-long-float (read-from-string "3")))
 
 (parachute:define-test float-features-overflow-or-inexact-trapped
     :compile-at :compile-time
     (parachute:true
      (float-features:float-infinity-p
       (float-features:with-float-traps-masked (:overflow :inexact)
-        (let ((n (random 100)))
-          (+ (foo-float-features-2 n) (bar-float-features-2 n)))))))
+        (+ (- (symbol-value 'most-positive-long-float) (read-from-string "3"))
+           (- (symbol-value 'most-positive-long-float) (read-from-string "3")))))))
 
 (parachute:define-test float-features-overflow-or-inexact-non-trapped
     :compile-at :compile-time
     (parachute:true
      (handler-case
-         (let ((n (random 100)))
-           (float-features:with-float-traps-masked ()
-             (+ (foo-float-features-2 n) (bar-float-features-2 n))))
+         (float-features:with-float-traps-masked ()
+           (+ (- (symbol-value 'most-positive-long-float) (read-from-string "3"))
+              (- (symbol-value 'most-positive-long-float) (read-from-string "3"))))
        (floating-point-inexact (error)
          (values t error))
        (floating-point-overflow (error)
          (values t error)))))
-
-(defun foo-float-features-3 (n)
-  (read-from-string "0.0"))
-
-(defun bar-float-features-3 (n)
-  (read-from-string "0.0"))
 
 (parachute:define-test float-features-invalid-trapped
     :compile-at :compile-time
     (parachute:true
      (float-features:float-nan-p
       (float-features:with-float-traps-masked (:invalid)
-        (let ((n (random 100)))
-          (/ (foo-float-features-3 n) (bar-float-features-3 n)))))))
+        (/ (read-from-string "0.0") (read-from-string "0.0"))))))
 
 (parachute:define-test float-features-invalid-non-trapped
     :compile-at :compile-time
     (parachute:true
      (handler-case
          (float-features:with-float-traps-masked ()
-           (let ((n (random 100)))
-             (/ (foo-float-features-3 n) (bar-float-features-3 n))))
+           (/ (read-from-string "0.0") (read-from-string "0.0")))
        (floating-point-inexact (error)
          (values t error))
        (division-by-zero (error)


### PR DESCRIPTION
(For reference, tests that are modified by this pull request were introduced in #11.)

When compiling/running tests, warnings are signaled due to `foo-...` and `bar-...` functions having an unused argument.

This updates those tests by removing temporary functions `foo-...` and `bar-...`, as well as local `foo` and `bar` in analogous tests. It seems that their only purpose is to prevent constant folding, but it doesn't work well since they can be inlined. Instead, `read-from-string` and `symbol-value` are used to prevent constant folding.